### PR TITLE
feat: add browseWithoutSelecting prop

### DIFF
--- a/src/lib/DateInput.svelte
+++ b/src/lib/DateInput.svelte
@@ -22,14 +22,10 @@
       subscribe: innerStore.subscribe,
       set: (d: Date | null) => {
         if (d === null) {
-          if (!browseWithoutSelecting) {
-            innerStore.set(null)
-          }
+          innerStore.set(null)
           value = d
         } else if (d.getTime() !== $innerStore?.getTime()) {
-          if (!browseWithoutSelecting) {
-            innerStore.set(d)
-          }
+          innerStore.set(d)
           value = d
         }
       },
@@ -140,9 +136,7 @@
     if (closeOnSelection) {
       visible = false
     }
-    if (browseWithoutSelecting) {
-      innerStore.set(value)
-    }
+    innerStore.set(value)
   }
 </script>
 

--- a/src/lib/DateInput.svelte
+++ b/src/lib/DateInput.svelte
@@ -22,10 +22,14 @@
       subscribe: innerStore.subscribe,
       set: (d: Date | null) => {
         if (d === null) {
-          innerStore.set(null)
+          if (!delayUpdate) {
+            innerStore.set(null)
+          }
           value = d
         } else if (d.getTime() !== $innerStore?.getTime()) {
-          innerStore.set(d)
+          if (!delayUpdate) {
+            innerStore.set(d)
+          }
           value = d
         }
       },
@@ -101,6 +105,8 @@
   export let visible = false
   /** Close the date popup when a date is selected */
   export let closeOnSelection = false
+  /** Wait with updating the date until a date is selected */
+  export let delayUpdate = false
 
   // handle on:focusout for parent element. If the parent element loses
   // focus (e.g input element), visible is set to false
@@ -133,6 +139,9 @@
     dispatch('select', e.detail)
     if (closeOnSelection) {
       visible = false
+    }
+    if (delayUpdate) {
+      innerStore.set(value)
     }
   }
 </script>

--- a/src/lib/DateInput.svelte
+++ b/src/lib/DateInput.svelte
@@ -22,12 +22,12 @@
       subscribe: innerStore.subscribe,
       set: (d: Date | null) => {
         if (d === null) {
-          if (!delayUpdate) {
+          if (!browseWithoutSelecting) {
             innerStore.set(null)
           }
           value = d
         } else if (d.getTime() !== $innerStore?.getTime()) {
-          if (!delayUpdate) {
+          if (!browseWithoutSelecting) {
             innerStore.set(d)
           }
           value = d
@@ -106,7 +106,7 @@
   /** Close the date popup when a date is selected */
   export let closeOnSelection = false
   /** Wait with updating the date until a date is selected */
-  export let delayUpdate = false
+  export let browseWithoutSelecting = false
 
   // handle on:focusout for parent element. If the parent element loses
   // focus (e.g input element), visible is set to false
@@ -140,7 +140,7 @@
     if (closeOnSelection) {
       visible = false
     }
-    if (delayUpdate) {
+    if (browseWithoutSelecting) {
       innerStore.set(value)
     }
   }

--- a/src/lib/DateInput.svelte
+++ b/src/lib/DateInput.svelte
@@ -165,6 +165,7 @@
         {min}
         {max}
         {locale}
+        {browseWithoutSelecting}
       />
     </div>
   {/if}

--- a/src/lib/DateInput.svelte
+++ b/src/lib/DateInput.svelte
@@ -136,7 +136,6 @@
     if (closeOnSelection) {
       visible = false
     }
-    innerStore.set(value)
   }
 </script>
 

--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -29,7 +29,7 @@
   /** Update the shownDate. The date is only selected if a date is already selected */
   function updateShownDate(updater: (date: Date) => Date) {
     shownDate = updater(new Date(shownDate.getTime()))
-    if (value && shownDate.getTime() !== value.getTime()) {
+    if (!browseWithoutSelecting && value && shownDate.getTime() !== value.getTime()) {
       setValue(shownDate)
     }
   }
@@ -64,14 +64,11 @@
   // be highlighted.
   let highlightedDate = shownDate
   function shouldHighlightCalendarDay(day: CalendarDay) {
-    return (
-      day.month === month &&
-      day.number === dayOfMonth &&
-      (!browseWithoutSelecting ||
-        (day.year === year &&
-          year === highlightedDate.getFullYear() &&
-          month === highlightedDate.getMonth()))
-    )
+    return browseWithoutSelecting
+      ? day.year === highlightedDate.getFullYear() &&
+          day.month === highlightedDate.getMonth() &&
+          day.number === highlightedDate.getDate()
+      : day.month === month && day.number === dayOfMonth
   }
 
   let year = shownDate.getFullYear()
@@ -206,30 +203,31 @@
       shiftKeydown(e)
       return
     } else if (e.key === 'ArrowUp') {
-      updateValue((value) => {
+      updateShownDate((value) => {
         value.setDate(value.getDate() - 7)
         highlightedDate = value
         return value
       })
     } else if (e.key === 'ArrowDown') {
-      updateValue((value) => {
+      updateShownDate((value) => {
         value.setDate(value.getDate() + 7)
         highlightedDate = value
         return value
       })
     } else if (e.key === 'ArrowLeft') {
-      updateValue((value) => {
+      updateShownDate((value) => {
         value.setDate(value.getDate() - 1)
         highlightedDate = value
         return value
       })
     } else if (e.key === 'ArrowRight') {
-      updateValue((value) => {
+      updateShownDate((value) => {
         value.setDate(value.getDate() + 1)
         highlightedDate = value
         return value
       })
     } else if (e.key === 'Enter') {
+      setValue(shownDate)
       dispatch('select')
     } else {
       return

--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -65,11 +65,12 @@
   let highlightedDate = shownDate
   function shouldHighlightCalendarDay(day: CalendarDay) {
     return (
-      day.year === year &&
       day.month === month &&
       day.number === dayOfMonth &&
       (!browseWithoutSelecting ||
-        (year === highlightedDate.getFullYear() && month === highlightedDate.getMonth()))
+        (day.year === year &&
+          year === highlightedDate.getFullYear() &&
+          month === highlightedDate.getMonth()))
     )
   }
 

--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -210,7 +210,7 @@
       })
     } else if (e.key === 'Enter') {
       dispatch('select')
-    }else {
+    } else {
       return
     }
     e.preventDefault()

--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -57,6 +57,21 @@
   /** Locale object for internationalization */
   export let locale: Locale = {}
   $: iLocale = getInnerLocale(locale)
+  /** Wait with updating the date until a date is selected */
+  export let browseWithoutSelecting = false
+  // The highlighted date shown in the popup. When `browseWithoutSelecting`
+  // is set to `true`, it is used to help determine whether a calendar day should
+  // be highlighted.
+  let highlightedDate = shownDate
+  function shouldHighlightCalendarDay(day: CalendarDay) {
+    return (
+      day.year === year &&
+      day.month === month &&
+      day.number === dayOfMonth &&
+      (!browseWithoutSelecting ||
+        (year === highlightedDate.getFullYear() && month === highlightedDate.getMonth()))
+    )
+  }
 
   let year = shownDate.getFullYear()
   const getYear = (tmpPickerDate: Date) => (year = tmpPickerDate.getFullYear())
@@ -113,6 +128,7 @@
         value.setFullYear(calendarDay.year)
         value.setMonth(calendarDay.month)
         value.setDate(calendarDay.number)
+        highlightedDate = value
         return value
       })
     }
@@ -191,21 +207,25 @@
     } else if (e.key === 'ArrowUp') {
       updateValue((value) => {
         value.setDate(value.getDate() - 7)
+        highlightedDate = value
         return value
       })
     } else if (e.key === 'ArrowDown') {
       updateValue((value) => {
         value.setDate(value.getDate() + 7)
+        highlightedDate = value
         return value
       })
     } else if (e.key === 'ArrowLeft') {
       updateValue((value) => {
         value.setDate(value.getDate() - 1)
+        highlightedDate = value
         return value
       })
     } else if (e.key === 'ArrowRight') {
       updateValue((value) => {
         value.setDate(value.getDate() + 1)
+        highlightedDate = value
         return value
       })
     } else if (e.key === 'Enter') {
@@ -292,7 +312,7 @@
             class="cell"
             on:click={() => selectDay(calendarDay)}
             class:disabled={!dayIsInRange(calendarDay, min, max)}
-            class:selected={calendarDay.month === month && calendarDay.number === dayOfMonth}
+            class:selected={shouldHighlightCalendarDay(calendarDay)}
             class:other-month={calendarDay.month !== month}
           >
             <span>{calendarDay.number}</span>

--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -208,7 +208,9 @@
         value.setDate(value.getDate() + 1)
         return value
       })
-    } else {
+    } else if (e.key === 'Enter') {
+      dispatch('select')
+    }else {
       return
     }
     e.preventDefault()

--- a/src/routes/_DateInput.svelte
+++ b/src/routes/_DateInput.svelte
@@ -10,7 +10,7 @@
   let valid: boolean
   let visible: boolean
   let closeOnSelection: boolean
-  let delayUpdate: boolean
+  let browseWithoutSelecting: boolean
   let format: string
 </script>
 
@@ -25,7 +25,7 @@
     bind:format
     bind:visible
     bind:closeOnSelection
-    bind:delayUpdate
+    bind:browseWithoutSelecting
   />
 
   <svelte:fragment slot="right">
@@ -38,7 +38,7 @@
     <Prop label="format" bind:value={format} />
     <Prop label="visible" bind:value={visible} />
     <Prop label="closeOnSelection" bind:value={closeOnSelection} />
-    <Prop label="delayUpdate" bind:value={delayUpdate} />
+    <Prop label="browseWithoutSelecting" bind:value={browseWithoutSelecting} />
     <Prop label="locale">Default</Prop>
   </svelte:fragment>
 </Split>

--- a/src/routes/_DateInput.svelte
+++ b/src/routes/_DateInput.svelte
@@ -10,6 +10,7 @@
   let valid: boolean
   let visible: boolean
   let closeOnSelection: boolean
+  let delayUpdate: boolean
   let format: string
 </script>
 
@@ -24,6 +25,7 @@
     bind:format
     bind:visible
     bind:closeOnSelection
+    bind:delayUpdate
   />
 
   <svelte:fragment slot="right">
@@ -36,6 +38,7 @@
     <Prop label="format" bind:value={format} />
     <Prop label="visible" bind:value={visible} />
     <Prop label="closeOnSelection" bind:value={closeOnSelection} />
+    <Prop label="delayUpdate" bind:value={delayUpdate} />
     <Prop label="locale">Default</Prop>
   </svelte:fragment>
 </Split>

--- a/src/routes/_DatePicker.svelte
+++ b/src/routes/_DatePicker.svelte
@@ -12,11 +12,12 @@
   let min: Date
   let max: Date
   let locale = localeFromDateFnsLocale(hy)
+  let browseWithoutSelecting: boolean
 </script>
 
 <Split>
   <div class="left" slot="left">
-    <DatePicker bind:value bind:min bind:max {locale} />
+    <DatePicker bind:value bind:min bind:max {locale} bind:browseWithoutSelecting />
   </div>
   <div slot="right">
     <h3 class="no-top">Props</h3>
@@ -24,5 +25,6 @@
     <Prop label="min" bind:value={min} />
     <Prop label="max" bind:value={max} />
     <Prop label="locale">date-fns <code>hy</code></Prop>
+    <Prop label="browseWithoutSelecting" bind:value={browseWithoutSelecting} />
   </div>
 </Split>

--- a/src/routes/_prop.svelte
+++ b/src/routes/_prop.svelte
@@ -43,7 +43,7 @@
     padding: 5px 0px
   .label
     display: inline-block
-    width: 140px
+    width: 195px
     flex-shrink: 0
   input[type='text'], textarea
     color: var(--foreground)

--- a/src/routes/docs.md
+++ b/src/routes/docs.md
@@ -29,17 +29,18 @@ The component will not assign a date value until a specific date is selected in 
 
 ### Props
 
-| Prop               | Type         | Description                                  |
-| :----------------- | :----------- | :------------------------------------------- |
-| `value`            | Date \| null | Date value                                   |
-| `min`              | Date         | The earliest value the user can select       |
-| `max`              | Date         | The latest value the user can select         |
-| `placeholder`      | string       | Placeholder used when date value is null     |
-| `valid`            | bool         | Whether the text is valid                    |
-| `format`           | string       | Format string                                |
-| `visible`          | bool         | Whether the date popup is visible            |
-| `closeOnSelection` | bool         | Close the date popup when a date is selected |
-| `locale`           | Locale       | Locale object for internationalization       |
+| Prop               | Type         | Description                                          |
+| :----------------- | :----------- | :--------------------------------------------------- |
+| `value`            | Date \| null | Date value                                           |
+| `min`              | Date         | The earliest value the user can select               |
+| `max`              | Date         | The latest value the user can select                 |
+| `placeholder`      | string       | Placeholder used when date value is null             |
+| `valid`            | bool         | Whether the text is valid                            |
+| `format`           | string       | Format string                                        |
+| `visible`          | bool         | Whether the date popup is visible                    |
+| `closeOnSelection` | bool         | Close the date popup when a date is selected         |
+| `delayUpdate`      | bool         | Wait with updating the date until a date is selected |
+| `locale`           | Locale       | Locale object for internationalization               |
 
 #### Format string
 

--- a/src/routes/docs.md
+++ b/src/routes/docs.md
@@ -29,18 +29,18 @@ The component will not assign a date value until a specific date is selected in 
 
 ### Props
 
-| Prop               | Type         | Description                                          |
-| :----------------- | :----------- | :--------------------------------------------------- |
-| `value`            | Date \| null | Date value                                           |
-| `min`              | Date         | The earliest value the user can select               |
-| `max`              | Date         | The latest value the user can select                 |
-| `placeholder`      | string       | Placeholder used when date value is null             |
-| `valid`            | bool         | Whether the text is valid                            |
-| `format`           | string       | Format string                                        |
-| `visible`          | bool         | Whether the date popup is visible                    |
-| `closeOnSelection` | bool         | Close the date popup when a date is selected         |
-| `delayUpdate`      | bool         | Wait with updating the date until a date is selected |
-| `locale`           | Locale       | Locale object for internationalization               |
+| Prop                     | Type         | Description                                          |
+| :----------------------- | :----------- | :--------------------------------------------------- |
+| `value`                  | Date \| null | Date value                                           |
+| `min`                    | Date         | The earliest value the user can select               |
+| `max`                    | Date         | The latest value the user can select                 |
+| `placeholder`            | string       | Placeholder used when date value is null             |
+| `valid`                  | bool         | Whether the text is valid                            |
+| `format`                 | string       | Format string                                        |
+| `visible`                | bool         | Whether the date popup is visible                    |
+| `closeOnSelection`       | bool         | Close the date popup when a date is selected         |
+| `browseWithoutSelecting` | bool         | Wait with updating the date until a date is selected |
+| `locale`                 | Locale       | Locale object for internationalization               |
 
 #### Format string
 

--- a/src/routes/docs.md
+++ b/src/routes/docs.md
@@ -62,12 +62,13 @@ The component will not assign a date value until a specific date is selected in 
 
 ### Props
 
-| Prop     | Type         | Description                            |
-| :------- | :----------- | :------------------------------------- |
-| `value`  | Date \| null | Date value                             |
-| `min`    | Date         | The earliest year the user can select  |
-| `max`    | Date         | The latest year the user can select    |
-| `locale` | Locale       | Locale object for internationalization |
+| Prop                     | Type         | Description                                          |
+| :----------------------- | :----------- | :--------------------------------------------------- |
+| `value`                  | Date \| null | Date value                                           |
+| `min`                    | Date         | The earliest year the user can select                |
+| `max`                    | Date         | The latest year the user can select                  |
+| `locale`                 | Locale       | Locale object for internationalization               |
+| `browseWithoutSelecting` | bool         | Wait with updating the date until a date is selected |
 
 ## Internationalization
 


### PR DESCRIPTION
This is aimed to resolve #15, so that when the year or month is changed, the date input does not immediately change. In addition the date input also does not change when the user uses the arrow keys in the date picker. With this change, the only time when the date picker would update the date input is when the user clicks on a date or presses the `Enter` key, given that the new `delayUpdate` property is set to `true` (`false` by default so it does not interfere with the current functionality).

@probablykasper please let me know if this is something you are interested in merging in. I'm happy to make additional changes.