### PR TITLE
fix: remove unnecessary input handler

### DIFF
--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -226,13 +226,7 @@
         >
       </div>
       <div class="dropdown month">
-        <select
-          bind:value={browseMonth}
-          on:input={() => {
-            setMonth(browseMonth)
-          }}
-          on:keydown={monthKeydown}
-        >
+        <select bind:value={browseMonth} on:keydown={monthKeydown}>
           {#each iLocale.months as monthName, i}
             <option
               disabled={new Date(browseYear, i, getMonthLength(browseYear, i), 23, 59, 59, 999) <


### PR DESCRIPTION
This closes #20.

I cross-referenced the implementation for the `year` dropdown and I think this `on:input` handler is not needed. Please let me know if that's a wrong assumption though. After removing it everything still seems to work (on both Safari and Firefox running on macOS).