### PR TITLE
Added CSS Variable to customize cursor on hover

### DIFF
--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -360,6 +360,7 @@
     &:hover
       background-color: rgba(#808080, 0.08)
       border: 1px solid rgba(#808080, 0.08)
+      cursor: var(--date-hover-arrow-cursor, pointer)
     svg
       width: 0.68rem
       height: 0.68rem
@@ -390,6 +391,8 @@
     border: 1px solid rgba(108, 120, 147, 0.3)
     outline: none
     transition: all 80ms cubic-bezier(0.4, 0.0, 0.2, 1)
+    &:hover
+      cursor: var(--month-year-select-hover-cursor, pointer)
 
   .header
     display: flex
@@ -415,6 +418,7 @@
     &:hover
       border: 1px solid rgba(#808080, 0.08)
       background-color: rgba(#808080, 0.08)
+      cursor: var(--date-hover-cursor, pointer)
     &.disabled
       visibility: hidden
     &.disabled:hover

--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { getMonthLength, getCalendarDays } from './date-utils'
-  import type { CalendarDay } from './date-utils'
-  import { getInnerLocale } from './locale'
-  import type { Locale } from './locale'
   import { createEventDispatcher } from 'svelte'
+  import type { CalendarDay } from './date-utils'
+  import { getCalendarDays, getMonthLength } from './date-utils'
+  import type { Locale } from './locale'
+  import { getInnerLocale } from './locale'
 
   const dispatch = createEventDispatcher<{ select: undefined }>()
 
@@ -360,7 +360,7 @@
     &:hover
       background-color: rgba(#808080, 0.08)
       border: 1px solid rgba(#808080, 0.08)
-      cursor: var(--date-hover-arrow-cursor, pointer)
+      cursor: var(--next-previous-arrow-hover-cursor, pointer)
     svg
       width: 0.68rem
       height: 0.68rem

--- a/src/routes/_DatePicker.svelte
+++ b/src/routes/_DatePicker.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { localeFromDateFnsLocale } from '$lib'
   import DatePicker from '$lib/DatePicker.svelte'
+  import { localeFromDateFnsLocale } from '$lib'
   import Prop from './_prop.svelte'
   import Split from './_split.svelte'
   // had to import it this way to avoid errors

--- a/src/routes/_DatePicker.svelte
+++ b/src/routes/_DatePicker.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-  import DatePicker from '$lib/DatePicker.svelte'
   import { localeFromDateFnsLocale } from '$lib'
+  import DatePicker from '$lib/DatePicker.svelte'
   import Prop from './_prop.svelte'
   import Split from './_split.svelte'
-
   // had to import it this way to avoid errors
   // in `npm run build:site` or `npm run check`:
   import hy from 'date-fns/locale/hy/index.js'

--- a/src/routes/docs.md
+++ b/src/routes/docs.md
@@ -114,7 +114,7 @@ Lengths:
 Hover Cursors:
 
 - `--date-hover-cursor`
-- `--date-hover-arrow-cursor`
+- `--next-previous-arrow-hover-cursor`
 - `--month-year-select-hover-cursor`
 
 Dark theme example:

--- a/src/routes/docs.md
+++ b/src/routes/docs.md
@@ -111,6 +111,12 @@ Lengths:
 
 - `--date-input-width`
 
+Hover Cursors:
+
+- `--date-hover-cursor`
+- `--date-hover-arrow-cursor`
+- `--month-year-select-hover-cursor`
+
 Dark theme example:
 
 ```css


### PR DESCRIPTION
Adds CSS variable to control the cursor on multiple hover cases:
- `--date-hover-arrow-cursor` (For date hover)
- `--month-year-select-hover-cursor` (For month and year select hover)
- `--next-previous-arrow-hover-cursor` (For next and previous arrow)

<img width="755" alt="Screen Shot 2022-10-10 at 12 25 17 AM" src="https://user-images.githubusercontent.com/35510032/194816371-b15246f2-c3bc-48fb-a1bf-7c02bcb00287.png">

Tested by changing line 18 in`_DatePicker.svelte`:
` <div class="left" slot="left">` - Original
 `<div class="left" slot="left" style="--date-hover-cursor: none; --next-previous-arrow-hover-cursor: none; --month-year-select-hover-cursor: none;">` - Modified (Cursor disappears on hover)

Note:
Please feel free to change the name of the css variables if you need to
Thanks for creating this component! Very handy!