### PR TITLE
dateinput: guard for undefined

### DIFF
--- a/src/lib/DateInput.svelte
+++ b/src/lib/DateInput.svelte
@@ -22,13 +22,13 @@
   const store = (() => {
     return {
       subscribe: innerStore.subscribe,
-      set: (d: Date | null) => {
-        if (d === null) {
+      set: (date: Date | null) => {
+        if (date === null || date === undefined) {
           innerStore.set(null)
-          value = d
-        } else if (d.getTime() !== $innerStore?.getTime()) {
-          innerStore.set(d)
-          value = d
+          value = date
+        } else if (date.getTime() !== $innerStore?.getTime()) {
+          innerStore.set(date)
+          value = date
         }
       },
     }


### PR DESCRIPTION
hey, thank you for the library!

Some libraries when doing validation pass undefined to the form fields and that ends up triggering an error in this component as "d.getTime" doesn't work anymore.
I've added a guard for undefined just in case.

I've change the variable name from d to date, but I don't feel too strongly about this. Feel free to leave it to `d` if you prefer.

let me know if anything of course.