### PR TITLE
fix : After selecting year/month datepicker getting closed in IOS

### DIFF
--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
-	import TimePicker from './TimePicker.svelte'
-	import { getMonthLength, getCalendarDays, type CalendarDay } from './date-utils.js'
-	import { getInnerLocale, type Locale } from './locale.js'
 	import { createEventDispatcher } from 'svelte'
+	import TimePicker from './TimePicker.svelte'
+	import { getCalendarDays, getMonthLength, type CalendarDay } from './date-utils.js'
+	import { getInnerLocale, type Locale } from './locale.js'
 
 	const dispatch = createEventDispatcher<{
 		/** Fires when the user selects a new value by clicking on a date or by pressing enter */
 		select: Date
 	}>()
+
+	let monthDivRef: HTMLDivElement
+	let yearDivRef: HTMLDivElement
 
 	function cloneDate(d: Date) {
 		return new Date(d.getTime())
@@ -235,11 +238,14 @@
 					/></svg
 				>
 			</button>
-			<div class="dropdown month">
+			<div class="dropdown month" tabindex="-1" bind:this={monthDivRef}>
 				<select
 					value={browseMonth}
 					on:keydown={monthKeydown}
-					on:input={(e) => setMonth(parseInt(e.currentTarget.value))}
+					on:input={(e) => {
+						setMonth(parseInt(e.currentTarget.value))
+						monthDivRef && monthDivRef.focus()
+					}}
 				>
 					{#each iLocale.months as monthName, i}
 						<option
@@ -265,10 +271,13 @@
 					><path d="M6 0l12 12-12 12z" transform="rotate(90, 12, 12)" /></svg
 				>
 			</div>
-			<div class="dropdown year">
+			<div class="dropdown year" tabindex="-1" bind:this={yearDivRef}>
 				<select
 					value={browseYear}
-					on:input={(e) => setYear(parseInt(e.currentTarget.value))}
+					on:input={(e) => {
+						setYear(parseInt(e.currentTarget.value))
+						yearDivRef && yearDivRef.focus()
+					}}
 					on:keydown={yearKeydown}
 				>
 					{#each years as v}

--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -384,8 +384,12 @@
 			box-sizing: content-box
 	.month
 		flex-grow: 1
+		&:focus 
+			outline: none
 	.year
 		flex-grow: 1
+		&:focus 
+			outline: none
 	svg
 		display: block
 		fill: var(--date-picker-foreground, #000000)


### PR DESCRIPTION

In IOS select tag looses focus, since its default behaviour of IOS safari to focus out from select tag once the option is selected.

so here we focus on wrapper div of select tag, this makes wrapper div as the related target in the onFocusOut event, and visible still remains true