### PR TITLE
feat: add `disabledDates` and `enabledDates` to DatePicker and DateInput

### DIFF
--- a/src/lib/DateInput.svelte
+++ b/src/lib/DateInput.svelte
@@ -101,6 +101,9 @@
 	/** Show a time picker with the specified precision */
 	export let timePrecision: 'minute' | 'second' | 'millisecond' | null = null
 
+	/** Disabled dates on calendar*/
+	export let disabledDates: Date[] = []
+
 	// handle on:focusout for parent element. If the parent element loses
 	// focus (e.g input element), visible is set to false
 	function onFocusOut(e: FocusEvent) {
@@ -232,6 +235,7 @@
 				{locale}
 				{browseWithoutSelecting}
 				{timePrecision}
+				{disabledDates}
 			>
 				<slot />
 			</DateTimePicker>

--- a/src/lib/DateInput.svelte
+++ b/src/lib/DateInput.svelte
@@ -104,6 +104,10 @@
 	/** Disabled dates on calendar*/
 	export let disabledDates: Date[] = []
 
+	/** Enabled dates. Only days listed in this array will be enabled.
+	 * disabledDates prop will be ignored if this is used */
+	export let enabledDates: Date[] = []
+
 	// handle on:focusout for parent element. If the parent element loses
 	// focus (e.g input element), visible is set to false
 	function onFocusOut(e: FocusEvent) {
@@ -236,6 +240,7 @@
 				{browseWithoutSelecting}
 				{timePrecision}
 				{disabledDates}
+				{enabledDates}
 			>
 				<slot />
 			</DateTimePicker>

--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -169,9 +169,9 @@
 	function isDisabledDate(calendarDay: CalendarDay) {
 		return disabledDates.find((day) => {
 			return (
-				day.getFullYear() === calendarDay.year &&
-				day.getMonth() === calendarDay.month &&
-				day.getDate() === calendarDay.number
+				day?.getFullYear() === calendarDay.year &&
+				day?.getMonth() === calendarDay.month &&
+				day?.getDate() === calendarDay.number
 			)
 		})
 	}
@@ -179,9 +179,9 @@
 	function isEnabledDate(calendarDay: CalendarDay) {
 		return enabledDates.find((day) => {
 			return (
-				day.getFullYear() === calendarDay.year &&
-				day.getMonth() === calendarDay.month &&
-				day.getDate() === calendarDay.number
+				day?.getFullYear() === calendarDay.year &&
+				day?.getMonth() === calendarDay.month &&
+				day?.getDate() === calendarDay.number
 			)
 		})
 	}

--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -166,6 +166,22 @@
 		}
 	}
 
+	function isDisabledYear(year: number) {
+		return enabledDates?.length > 0
+			? enabledDates.filter((day) => {
+					return day?.getFullYear() === year
+			  }).length === 0
+			: false
+	}
+
+	function isDisabledMonth(date: Date) {
+		return enabledDates?.length > 0
+			? enabledDates.filter((day) => {
+					return day?.getFullYear() === date.getFullYear() && day?.getMonth() === date.getMonth()
+			  }).length === 0
+			: false
+	}
+
 	function isDisabledDate(calendarDay: CalendarDay) {
 		return disabledDates.find((day) => {
 			return (
@@ -307,7 +323,9 @@
 					{#each iLocale.months as monthName, i}
 						<option
 							disabled={new Date(browseYear, i, getMonthLength(browseYear, i), 23, 59, 59, 999) <
-								min || new Date(browseYear, i) > max}
+								min ||
+								new Date(browseYear, i) > max ||
+								isDisabledMonth(new Date(browseYear, i))}
 							value={i}>{monthName}</option
 						>
 					{/each}
@@ -335,7 +353,7 @@
 					on:keydown={yearKeydown}
 				>
 					{#each years as v}
-						<option value={v}>{v}</option>
+						<option disabled={isDisabledYear(v)} value={v}>{v}</option>
 					{/each}
 				</select>
 				<!-- style <select> button without affecting menu popup -->

--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -59,6 +59,9 @@
 	export let max = new Date(defaultDate.getFullYear(), 11, 31, 23, 59, 59, 999)
 	/** Disabled dates on calendar*/
 	export let disabledDates: Date[] = []
+	/** Enabled dates. Only days listed in this array will be enabled.
+	 * disabledDates prop will be ignored if this is used */
+	export let enabledDates: Date[] = []
 
 	$: if (value && value > max) {
 		setValue(max)
@@ -173,13 +176,26 @@
 		})
 	}
 
+	function isEnabledDate(calendarDay: CalendarDay) {
+		return enabledDates.find((day) => {
+			return (
+				day.getFullYear() === calendarDay.year &&
+				day.getMonth() === calendarDay.month &&
+				day.getDate() === calendarDay.number
+			)
+		})
+	}
+
 	function dayIsInRange(calendarDay: CalendarDay, min: Date, max: Date) {
 		const date = new Date(calendarDay.year, calendarDay.month, calendarDay.number)
 		const minDate = new Date(min.getFullYear(), min.getMonth(), min.getDate())
 		const maxDate = new Date(max.getFullYear(), max.getMonth(), max.getDate())
 
-		const disabled = isDisabledDate(calendarDay)
-		return date >= minDate && date <= maxDate && !disabled
+		return (
+			date >= minDate &&
+			date <= maxDate &&
+			(enabledDates.length === 0 ? !isDisabledDate(calendarDay) : isEnabledDate(calendarDay))
+		)
 	}
 	function shiftKeydown(e: KeyboardEvent) {
 		if (e.shiftKey && e.key === 'ArrowUp') {
@@ -357,23 +373,25 @@
 		{#each Array(6) as _, weekIndex}
 			<div class="week">
 				{#each calendarDays.slice(weekIndex * 7, weekIndex * 7 + 7) as calendarDay}
-					{#key disabledDates}
-						<!-- svelte-ignore a11y-click-events-have-key-events -->
-						<div
-							class="cell"
-							on:click={() => selectDay(calendarDay)}
-							class:disabled={!dayIsInRange(calendarDay, min, max)}
-							class:selected={value &&
-								calendarDay.year === value.getFullYear() &&
-								calendarDay.month === value.getMonth() &&
-								calendarDay.number === value.getDate()}
-							class:today={calendarDay.year === todayDate.getFullYear() &&
-								calendarDay.month === todayDate.getMonth() &&
-								calendarDay.number === todayDate.getDate()}
-							class:other-month={calendarDay.month !== browseMonth}
-						>
-							<span>{calendarDay.number}</span>
-						</div>
+					{#key enabledDates}
+						{#key disabledDates}
+							<!-- svelte-ignore a11y-click-events-have-key-events -->
+							<div
+								class="cell"
+								on:click={() => selectDay(calendarDay)}
+								class:disabled={!dayIsInRange(calendarDay, min, max)}
+								class:selected={value &&
+									calendarDay.year === value.getFullYear() &&
+									calendarDay.month === value.getMonth() &&
+									calendarDay.number === value.getDate()}
+								class:today={calendarDay.year === todayDate.getFullYear() &&
+									calendarDay.month === todayDate.getMonth() &&
+									calendarDay.number === todayDate.getDate()}
+								class:other-month={calendarDay.month !== browseMonth}
+							>
+								<span>{calendarDay.number}</span>
+							</div>
+						{/key}
 					{/key}
 				{/each}
 			</div>

--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -57,6 +57,9 @@
 	export let min = new Date(defaultDate.getFullYear() - 20, 0, 1)
 	/** The latest year the user can select */
 	export let max = new Date(defaultDate.getFullYear(), 11, 31, 23, 59, 59, 999)
+	/** Disabled dates on calendar*/
+	export let disabledDates: Date[] = []
+
 	$: if (value && value > max) {
 		setValue(max)
 	} else if (value && value < min) {
@@ -159,11 +162,24 @@
 			dispatch('select', cloneDate(browseDate))
 		}
 	}
+
+	function isDisabledDate(calendarDay: CalendarDay) {
+		return disabledDates.find((day) => {
+			return (
+				day.getFullYear() === calendarDay.year &&
+				day.getMonth() === calendarDay.month &&
+				day.getDate() === calendarDay.number
+			)
+		})
+	}
+
 	function dayIsInRange(calendarDay: CalendarDay, min: Date, max: Date) {
 		const date = new Date(calendarDay.year, calendarDay.month, calendarDay.number)
 		const minDate = new Date(min.getFullYear(), min.getMonth(), min.getDate())
 		const maxDate = new Date(max.getFullYear(), max.getMonth(), max.getDate())
-		return date >= minDate && date <= maxDate
+
+		const disabled = isDisabledDate(calendarDay)
+		return date >= minDate && date <= maxDate && !disabled
 	}
 	function shiftKeydown(e: KeyboardEvent) {
 		if (e.shiftKey && e.key === 'ArrowUp') {
@@ -341,22 +357,24 @@
 		{#each Array(6) as _, weekIndex}
 			<div class="week">
 				{#each calendarDays.slice(weekIndex * 7, weekIndex * 7 + 7) as calendarDay}
-					<!-- svelte-ignore a11y-click-events-have-key-events -->
-					<div
-						class="cell"
-						on:click={() => selectDay(calendarDay)}
-						class:disabled={!dayIsInRange(calendarDay, min, max)}
-						class:selected={value &&
-							calendarDay.year === value.getFullYear() &&
-							calendarDay.month === value.getMonth() &&
-							calendarDay.number === value.getDate()}
-						class:today={calendarDay.year === todayDate.getFullYear() &&
-							calendarDay.month === todayDate.getMonth() &&
-							calendarDay.number === todayDate.getDate()}
-						class:other-month={calendarDay.month !== browseMonth}
-					>
-						<span>{calendarDay.number}</span>
-					</div>
+					{#key disabledDates}
+						<!-- svelte-ignore a11y-click-events-have-key-events -->
+						<div
+							class="cell"
+							on:click={() => selectDay(calendarDay)}
+							class:disabled={!dayIsInRange(calendarDay, min, max)}
+							class:selected={value &&
+								calendarDay.year === value.getFullYear() &&
+								calendarDay.month === value.getMonth() &&
+								calendarDay.number === value.getDate()}
+							class:today={calendarDay.year === todayDate.getFullYear() &&
+								calendarDay.month === todayDate.getMonth() &&
+								calendarDay.number === todayDate.getDate()}
+							class:other-month={calendarDay.month !== browseMonth}
+						>
+							<span>{calendarDay.number}</span>
+						</div>
+					{/key}
 				{/each}
 			</div>
 		{/each}

--- a/src/routes/DateInput.svelte
+++ b/src/routes/DateInput.svelte
@@ -20,7 +20,7 @@
 	let disabledDay1 = new Date()
 	let disabledDay2 = new Date(disabledDay1)
 	disabledDay2.setDate(disabledDay1.getDate() + 1)
-	let disabledDates = [disabledDay1, disabledDay2].filter(d=>d!== undefined)
+	let disabledDates = [disabledDay1, disabledDay2].filter((d) => d !== undefined)
 </script>
 
 <Split>

--- a/src/routes/DateInput.svelte
+++ b/src/routes/DateInput.svelte
@@ -20,7 +20,7 @@
 	let disabledDay1 = new Date()
 	let disabledDay2 = new Date(disabledDay1)
 	disabledDay2.setDate(disabledDay1.getDate() + 1)
-	let disabledDates = [disabledDay1, disabledDay2]
+	let disabledDates = [disabledDay1, disabledDay2].filter(d=>d!== undefined)
 </script>
 
 <Split>

--- a/src/routes/DateInput.svelte
+++ b/src/routes/DateInput.svelte
@@ -17,6 +17,10 @@
 	let format: string
 	let dynamicPositioning: boolean = true
 	let timePrecision: 'minute' | 'second' | 'millisecond' | null = null
+	let disabledDay1 = new Date()
+	let disabledDay2 = new Date(disabledDay1)
+	disabledDay2.setDate(disabledDay1.getDate() + 1)
+	let disabledDates = [disabledDay1, disabledDay2]
 </script>
 
 <Split>
@@ -36,6 +40,7 @@
 		bind:browseWithoutSelecting
 		bind:dynamicPositioning
 		bind:timePrecision
+		bind:disabledDates
 	/>
 
 	<svelte:fragment slot="right">
@@ -59,5 +64,8 @@
 			bind:value={timePrecision}
 			values={[null, 'minute', 'second', 'millisecond']}>{timePrecision}</Prop
 		>
+		{#each disabledDates as day, index}
+			<Prop label="disabledDate {index + 1}" bind:value={day} />
+		{/each}
 	</svelte:fragment>
 </Split>

--- a/src/routes/DatePicker.svelte
+++ b/src/routes/DatePicker.svelte
@@ -18,6 +18,14 @@
 	let disabledDay2 = new Date(disabledDay1)
 	disabledDay2.setDate(disabledDay1.getDate() + 1)
 	let disabledDates = [disabledDay1, disabledDay2]
+
+	let enabledDates = [new Date()]
+	const day2 = new Date()
+	day2.setDate(day2.getDate() + 3)
+	enabledDates.push(day2)
+	const day3 = new Date(day2)
+	day3.setDate(day3.getDate() + 3)
+	enabledDates.push(day3)
 </script>
 
 <Split>
@@ -29,7 +37,7 @@
 			{locale}
 			bind:browseWithoutSelecting
 			{timePrecision}
-			bind:disabledDates
+			{disabledDates}
 		/>
 	</div>
 	<div slot="right">
@@ -46,6 +54,37 @@
 		>
 		{#each disabledDates as day, index}
 			<Prop label="disabledDate {index + 1}" bind:value={day} />
+		{/each}
+	</div>
+</Split>
+
+<h3 class="no-top">DatePicker (enabledDates)</h3>
+<Split>
+	<div class="left" slot="left">
+		<DatePicker
+			bind:value
+			bind:min
+			bind:max
+			{locale}
+			bind:browseWithoutSelecting
+			{timePrecision}
+			{enabledDates}
+		/>
+	</div>
+	<div slot="right">
+		<h3 class="no-top">Props</h3>
+		<Prop label="value">{value}</Prop>
+		<Prop label="min" bind:value={min} />
+		<Prop label="max" bind:value={max} />
+		<Prop label="locale">date-fns <code>hy</code></Prop>
+		<Prop label="browseWithoutSelecting" bind:value={browseWithoutSelecting} />
+		<Prop
+			label="timePrecision"
+			bind:value={timePrecision}
+			values={[null, 'minute', 'second', 'millisecond']}>{timePrecision}</Prop
+		>
+		{#each enabledDates as day, index}
+			<Prop label="enableDate {index + 1}" bind:value={day} />
 		{/each}
 	</div>
 </Split>

--- a/src/routes/DatePicker.svelte
+++ b/src/routes/DatePicker.svelte
@@ -26,6 +26,12 @@
 	const day3 = new Date(day2)
 	day3.setDate(day3.getDate() + 3)
 	enabledDates.push(day3)
+	const day4 = new Date(day2)
+	day4.setMonth(day4.getMonth() - 1)
+	enabledDates.push(day4)
+	const day5 = new Date(day2)
+	day5.setFullYear(day5.getFullYear() - 1)
+	enabledDates.push(day5)
 </script>
 
 <Split>

--- a/src/routes/DatePicker.svelte
+++ b/src/routes/DatePicker.svelte
@@ -17,7 +17,7 @@
 	let disabledDay1 = new Date()
 	let disabledDay2 = new Date(disabledDay1)
 	disabledDay2.setDate(disabledDay1.getDate() + 1)
-	let disabledDates = [disabledDay1, disabledDay2].filter(d=>d!== undefined)
+	let disabledDates = [disabledDay1, disabledDay2].filter((d) => d !== undefined)
 
 	let enabledDates = [new Date()]
 	const day2 = new Date()

--- a/src/routes/DatePicker.svelte
+++ b/src/routes/DatePicker.svelte
@@ -17,7 +17,7 @@
 	let disabledDay1 = new Date()
 	let disabledDay2 = new Date(disabledDay1)
 	disabledDay2.setDate(disabledDay1.getDate() + 1)
-	let disabledDates = [disabledDay1, disabledDay2]
+	let disabledDates = [disabledDay1, disabledDay2].filter(d=>d!== undefined)
 
 	let enabledDates = [new Date()]
 	const day2 = new Date()

--- a/src/routes/DatePicker.svelte
+++ b/src/routes/DatePicker.svelte
@@ -13,11 +13,24 @@
 	let locale = localeFromDateFnsLocale(hy)
 	let browseWithoutSelecting: boolean
 	let timePrecision: 'minute' | 'second' | 'millisecond' | null = 'millisecond'
+
+	let disabledDay1 = new Date()
+	let disabledDay2 = new Date(disabledDay1)
+	disabledDay2.setDate(disabledDay1.getDate() + 1)
+	let disabledDates = [disabledDay1, disabledDay2]
 </script>
 
 <Split>
 	<div class="left" slot="left">
-		<DatePicker bind:value bind:min bind:max {locale} bind:browseWithoutSelecting {timePrecision} />
+		<DatePicker
+			bind:value
+			bind:min
+			bind:max
+			{locale}
+			bind:browseWithoutSelecting
+			{timePrecision}
+			bind:disabledDates
+		/>
 	</div>
 	<div slot="right">
 		<h3 class="no-top">Props</h3>
@@ -31,5 +44,8 @@
 			bind:value={timePrecision}
 			values={[null, 'minute', 'second', 'millisecond']}>{timePrecision}</Prop
 		>
+		{#each disabledDates as day, index}
+			<Prop label="disabledDate {index + 1}" bind:value={day} />
+		{/each}
 	</div>
 </Split>

--- a/src/routes/docs/+page.md
+++ b/src/routes/docs/+page.md
@@ -46,6 +46,7 @@ The component will not assign a date value until a specific date is selected in 
 | `browseWithoutSelecting` | bool                                          | Wait with updating the date until a value is selected         |
 | `dynamicPositioning`     | bool                                          | Dynamically postions the date popup to best fit on the screen |
 | `locale`                 | Locale                                        | Locale object for internationalization                        |
+| `disabledDates`          | Date[]                                        | Disable specific dates on the calendar                        |
 
 <h4 id="format-string">Format string</h4>
 
@@ -76,6 +77,7 @@ The component will not assign a date value until a specific date is selected in 
 | `timePrecision`          | "minute" \| "second" \| "millisecond" \| null | Show a time picker with the specified precision      |
 | `locale`                 | Locale                                        | Locale object for internationalization               |
 | `browseWithoutSelecting` | bool                                          | Wait with updating the date until a date is selected |
+| `disabledDates`          | Date[]                                        | Disable specific dates on the calendar               |
 
 <h2 id="internationalization">Internationalization</h2>
 

--- a/src/routes/docs/+page.md
+++ b/src/routes/docs/+page.md
@@ -47,6 +47,7 @@ The component will not assign a date value until a specific date is selected in 
 | `dynamicPositioning`     | bool                                          | Dynamically postions the date popup to best fit on the screen |
 | `locale`                 | Locale                                        | Locale object for internationalization                        |
 | `disabledDates`          | Date[]                                        | Disable specific dates on the calendar                        |
+| `enabledDates`           | Date[]                                        | Enable particular dates. disabledDates is ignored.            |
 
 <h4 id="format-string">Format string</h4>
 
@@ -78,6 +79,7 @@ The component will not assign a date value until a specific date is selected in 
 | `locale`                 | Locale                                        | Locale object for internationalization               |
 | `browseWithoutSelecting` | bool                                          | Wait with updating the date until a date is selected |
 | `disabledDates`          | Date[]                                        | Disable specific dates on the calendar               |
+| `enabledDates`           | Date[]                                        | Enable particular dates. disabledDates is ignored.   |
 
 <h2 id="internationalization">Internationalization</h2>
 


### PR DESCRIPTION
It would be nice if particular dates can be disabled or enabled while currently only can restrict by using `min` and `max` dates.

I added following two props.
- `disabledDates`: Date[]. Disable dates in the array.
- `enabledDates`: Date[]. Enable only dates in the array. If it is used, `disabledDates` is ignored.
- updated documentation for these two props

Please let me know your thought on this PR.

## Screenshots
- for DateInput
<img width="823" alt="image" src="https://github.com/probablykasper/date-picker-svelte/assets/2639701/2e06cbd8-76b0-415a-8a95-8acf8554ba47">

- for DatePicker. I added new datepicker for `enabledDates`.
![image](https://github.com/probablykasper/date-picker-svelte/assets/2639701/6f499ff5-5f16-406a-9731-2802535010cd)

- If enabledDates is used, disable year and month on dropdown
<img width="823" alt="image" src="https://github.com/probablykasper/date-picker-svelte/assets/2639701/0a35389f-3b71-46ef-ad7a-fe7bf28b6638">

<img width="823" alt="image" src="https://github.com/probablykasper/date-picker-svelte/assets/2639701/28f6811c-acf8-4b84-9db3-53615080b604">
