### PR TITLE
Possible fix for TimePrecision on min/max values are set

### DIFF
--- a/src/lib/TimePicker.svelte
+++ b/src/lib/TimePicker.svelte
@@ -103,7 +103,6 @@
 			browseDate.setMilliseconds(value)
 		}
 
-		browseDate = setTime(browseDate)
 		setText(browseDate)
 	}
 
@@ -134,6 +133,19 @@
 	function focus(e: FocusEvent & SpanEvent) {
 		select(e.currentTarget)
 	}
+
+	function focusout(e: FocusEvent) {
+		const node = e.currentTarget as HTMLElement
+		// Use setTimeout with 0ms delay to check focus after the browser has processed the current event cycle
+		// This is necessary because when switching focus between elements, the document.activeElement updates
+		// after the focusout event fires
+		setTimeout(() => {
+			if (!node.contains(document.activeElement)) {
+				browseDate = setTime(browseDate)
+				setText(browseDate)
+			}
+		}, 0)
+	}
 </script>
 
 {#if timePrecision}
@@ -146,6 +158,7 @@
 				e.preventDefault() // prevent text dragging
 			}
 		}}
+		on:focusout={focusout}
 	>
 		<span
 			bind:this={fields[0]}


### PR DESCRIPTION
Set it so time is not updated till after the time element is out of focus, this allows for keyboard inputs that may temporally set the time bellow or above the min/max values: #83 