### PR TITLE
Add `initialBrowseDate` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next
+- Add `initialBrowseDate` prop (@endaaman)
+
 ## 2.16.0 - 2025 Apr 2
 - Add `isDisabledDate` prop (@stinger567)
 

--- a/src/lib/DateInput.svelte
+++ b/src/lib/DateInput.svelte
@@ -14,7 +14,7 @@
 	}>()
 
 	/** Default date to display in picker before value is assigned */
-	const defaultDate = new Date()
+	export let defaultDate = new Date()
 
 	// inner date value store for preventing value updates (and also
 	// text updates as a result) when date is unchanged
@@ -234,6 +234,7 @@
 				on:focusout={onFocusOut}
 				on:select={onSelect}
 				bind:value={$store}
+				{defaultDate}
 				{min}
 				{max}
 				{locale}

--- a/src/lib/DateInput.svelte
+++ b/src/lib/DateInput.svelte
@@ -13,8 +13,8 @@
 		select: Date
 	}>()
 
-	/** Default date to display in picker before value is assigned */
-	export let defaultDate = new Date()
+	/** Initial date to show in the calendar when no value is selected */
+	export let initialBrowseDate = new Date()
 
 	// inner date value store for preventing value updates (and also
 	// text updates as a result) when date is unchanged
@@ -39,12 +39,12 @@
 
 	/** Date value */
 	export let value: Date | null = null
-	$: store.set(value ? toValidDate(defaultDate, value, min, max, isDisabledDate) : value)
+	$: store.set(value ? toValidDate(initialBrowseDate, value, min, max, isDisabledDate) : value)
 
 	/** The earliest value the user can select */
-	export let min = new Date(defaultDate.getFullYear() - 20, 0, 1)
+	export let min = new Date(initialBrowseDate.getFullYear() - 20, 0, 1)
 	/** The latest value the user can select */
-	export let max = new Date(defaultDate.getFullYear(), 11, 31, 23, 59, 59, 999)
+	export let max = new Date(initialBrowseDate.getFullYear(), 11, 31, 23, 59, 59, 999)
 	/** Set the input element's ID attribute */
 	export let id: string | null = null
 	/** Placeholder text to show when input field is empty */
@@ -79,7 +79,7 @@
 			const result = parse(text, formatTokens, $store)
 			if (result.date !== null) {
 				valid = true
-				store.set(toValidDate(defaultDate, result.date, min, max, isDisabledDate))
+				store.set(toValidDate(initialBrowseDate, result.date, min, max, isDisabledDate))
 			} else {
 				valid = false
 			}
@@ -234,7 +234,7 @@
 				on:focusout={onFocusOut}
 				on:select={onSelect}
 				bind:value={$store}
-				{defaultDate}
+				{initialBrowseDate}
 				{min}
 				{max}
 				{locale}

--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -47,7 +47,7 @@
 	const todayDate = new Date()
 
 	/** Default Date to use */
-	const defaultDate = new Date()
+	export let defaultDate = new Date()
 
 	/** Show a time picker with the specified precision */
 	export let timePrecision: 'minute' | 'second' | 'millisecond' | null = null

--- a/src/lib/DatePicker.svelte
+++ b/src/lib/DatePicker.svelte
@@ -46,15 +46,15 @@
 
 	const todayDate = new Date()
 
-	/** Default Date to use */
-	export let defaultDate = new Date()
+	/** Initial date to show in the calendar when no value is selected */
+	export let initialBrowseDate = new Date()
 
 	/** Show a time picker with the specified precision */
 	export let timePrecision: 'minute' | 'second' | 'millisecond' | null = null
 	/** The earliest year the user can select */
-	export let min = new Date(defaultDate.getFullYear() - 20, 0, 1)
+	export let min = new Date(initialBrowseDate.getFullYear() - 20, 0, 1)
 	/** The latest year the user can select */
-	export let max = new Date(defaultDate.getFullYear(), 11, 31, 23, 59, 59, 999)
+	export let max = new Date(initialBrowseDate.getFullYear(), 11, 31, 23, 59, 59, 999)
 	/** Disallow specific dates */
 	export let isDisabledDate: ((dateToCheck: Date) => boolean) | null = null
 
@@ -72,7 +72,7 @@
 	}
 
 	/** The date shown in the popup when none is selected */
-	let browseDate = value ? cloneDate(value) : cloneDate(clampDate(defaultDate, min, max))
+	let browseDate = value ? cloneDate(value) : cloneDate(clampDate(initialBrowseDate, min, max))
 	$: setBrowseDate(value)
 	function setBrowseDate(value: Date | null) {
 		if (browseDate.getTime() !== value?.getTime()) {

--- a/src/routes/DateInput.svelte
+++ b/src/routes/DateInput.svelte
@@ -8,6 +8,7 @@
 	let id: string
 	let placeholder: string
 	let value: Date
+	let defaultDate: Date
 	let min: Date
 	let max: Date
 	let valid: boolean
@@ -33,6 +34,7 @@
 		slot="left"
 		bind:id
 		bind:value
+		bind:defaultDate
 		bind:min
 		bind:max
 		bind:placeholder
@@ -51,6 +53,7 @@
 	<svelte:fragment slot="right">
 		<h3 class="no-top">Props</h3>
 		<Prop label="value">{value}</Prop>
+		<Prop label="defaultDate" bind:value={defaultDate} />
 		<Prop label="min" bind:value={min} />
 		<Prop label="max" bind:value={max} />
 		<Prop label="id" bind:value={id} />

--- a/src/routes/DateInput.svelte
+++ b/src/routes/DateInput.svelte
@@ -8,7 +8,7 @@
 	let id: string
 	let placeholder: string
 	let value: Date
-	let defaultDate: Date
+	let initialBrowseDate: Date
 	let min: Date
 	let max: Date
 	let valid: boolean
@@ -34,7 +34,7 @@
 		slot="left"
 		bind:id
 		bind:value
-		bind:defaultDate
+		bind:initialBrowseDate
 		bind:min
 		bind:max
 		bind:placeholder
@@ -53,7 +53,7 @@
 	<svelte:fragment slot="right">
 		<h3 class="no-top">Props</h3>
 		<Prop label="value">{value}</Prop>
-		<Prop label="defaultDate" bind:value={defaultDate} />
+		<Prop label="initialBrowseDate" bind:value={initialBrowseDate} />
 		<Prop label="min" bind:value={min} />
 		<Prop label="max" bind:value={max} />
 		<Prop label="id" bind:value={id} />

--- a/src/routes/DatePicker.svelte
+++ b/src/routes/DatePicker.svelte
@@ -6,7 +6,7 @@
 	import { hy, de, nb } from 'date-fns/locale'
 
 	let value: Date
-	let defaultDate: Date
+	let initialBrowseDate: Date
 	let min: Date
 	let max: Date
 	let locales = [
@@ -24,7 +24,7 @@
 	<div class="left" slot="left">
 		<DatePicker
 			bind:value
-			bind:defaultDate
+			bind:initialBrowseDate
 			bind:min
 			bind:max
 			locale={locale.value}
@@ -35,7 +35,7 @@
 	<div slot="right">
 		<h3 class="no-top">Props</h3>
 		<Prop label="value">{value}</Prop>
-		<Prop label="defaultDate" bind:value={defaultDate} />
+		<Prop label="initialBrowseDate" bind:value={initialBrowseDate} />
 		<Prop label="min" bind:value={min} />
 		<Prop label="max" bind:value={max} />
 		<Prop label="locale" bind:value={locale} values={locales} />

--- a/src/routes/DatePicker.svelte
+++ b/src/routes/DatePicker.svelte
@@ -6,6 +6,7 @@
 	import { hy, de, nb } from 'date-fns/locale'
 
 	let value: Date
+	let defaultDate: Date
 	let min: Date
 	let max: Date
 	let locales = [
@@ -23,6 +24,7 @@
 	<div class="left" slot="left">
 		<DatePicker
 			bind:value
+			bind:defaultDate
 			bind:min
 			bind:max
 			locale={locale.value}
@@ -33,6 +35,7 @@
 	<div slot="right">
 		<h3 class="no-top">Props</h3>
 		<Prop label="value">{value}</Prop>
+		<Prop label="defaultDate" bind:value={defaultDate} />
 		<Prop label="min" bind:value={min} />
 		<Prop label="max" bind:value={max} />
 		<Prop label="locale" bind:value={locale} values={locales} />

--- a/src/routes/docs/+page.md
+++ b/src/routes/docs/+page.md
@@ -32,7 +32,7 @@ The component will not assign a date value until a specific date is selected in 
 | Prop                     | Type                                          | Description                                                   |
 | :----------------------- | :-------------------------------------------- | :------------------------------------------------------------ |
 | `value`                  | Date \| null                                  | Date value                                                    |
-| `defaultDate`            | Date                                          | Default date to display in picker before value is assigned    |
+| `initialBrowseDate`      | Date                                          | Initial date to show in the calendar when no value is selected |
 | `min`                    | Date                                          | The earliest value the user can select                        |
 | `max`                    | Date                                          | The latest value the user can select                          |
 | `placeholder`            | string                                        | Placeholder used when date value is null                      |
@@ -73,7 +73,7 @@ The component will not assign a date value until a specific date is selected in 
 | Prop                     | Type                                          | Description                                          |
 | :----------------------- | :-------------------------------------------- | :--------------------------------------------------- |
 | `value`                  | Date \| null                                  | Date value                                           |
-| `defaultDate`            | Date                                          | Default Date to use                                  |
+| `initialBrowseDate`      | Date                                          | Initial date to show in the calendar when no value is selected |
 | `min`                    | Date                                          | The earliest year the user can select                |
 | `max`                    | Date                                          | The latest year the user can select                  |
 | `timePrecision`          | "minute" \| "second" \| "millisecond" \| null | Show a time picker with the specified precision      |

--- a/src/routes/docs/+page.md
+++ b/src/routes/docs/+page.md
@@ -29,25 +29,25 @@ The component will not assign a date value until a specific date is selected in 
 
 <h3 id="props">Props</h3>
 
-| Prop                     | Type                                          | Description                                                   |
-| :----------------------- | :-------------------------------------------- | :------------------------------------------------------------ |
-| `value`                  | Date \| null                                  | Date value                                                    |
+| Prop                     | Type                                          | Description                                                    |
+| :----------------------- | :-------------------------------------------- | :------------------------------------------------------------- |
+| `value`                  | Date \| null                                  | Date value                                                     |
 | `initialBrowseDate`      | Date                                          | Initial date to show in the calendar when no value is selected |
-| `min`                    | Date                                          | The earliest value the user can select                        |
-| `max`                    | Date                                          | The latest value the user can select                          |
-| `placeholder`            | string                                        | Placeholder used when date value is null                      |
-| `timePrecision`          | "minute" \| "second" \| "millisecond" \| null | Show a time picker with the specified precision               |
-| `id`                     | string \| null                                | Set the input element's ID attribute                          |
-| `valid`                  | bool                                          | Whether the text is valid                                     |
-| `format`                 | string                                        | Format string                                                 |
-| `visible`                | bool                                          | Whether the date popup is visible                             |
-| `disabled`               | bool                                          | Disable the input                                             |
-| `required`               | bool                                          | Require a value to submit form                                |
-| `closeOnSelection`       | bool                                          | Close the date popup when a date is selected                  |
-| `browseWithoutSelecting` | bool                                          | Wait with updating the date until a value is selected         |
-| `dynamicPositioning`     | bool                                          | Dynamically postions the date popup to best fit on the screen |
-| `locale`                 | Locale                                        | Locale object for internationalization                        |
-| `isDisabledDate`         | ((dateToCheck: Date) => boolean) \| null      | Disallow specific dates                                       |
+| `min`                    | Date                                          | The earliest value the user can select                         |
+| `max`                    | Date                                          | The latest value the user can select                           |
+| `placeholder`            | string                                        | Placeholder used when date value is null                       |
+| `timePrecision`          | "minute" \| "second" \| "millisecond" \| null | Show a time picker with the specified precision                |
+| `id`                     | string \| null                                | Set the input element's ID attribute                           |
+| `valid`                  | bool                                          | Whether the text is valid                                      |
+| `format`                 | string                                        | Format string                                                  |
+| `visible`                | bool                                          | Whether the date popup is visible                              |
+| `disabled`               | bool                                          | Disable the input                                              |
+| `required`               | bool                                          | Require a value to submit form                                 |
+| `closeOnSelection`       | bool                                          | Close the date popup when a date is selected                   |
+| `browseWithoutSelecting` | bool                                          | Wait with updating the date until a value is selected          |
+| `dynamicPositioning`     | bool                                          | Dynamically postions the date popup to best fit on the screen  |
+| `locale`                 | Locale                                        | Locale object for internationalization                         |
+| `isDisabledDate`         | ((dateToCheck: Date) => boolean) \| null      | Disallow specific dates                                        |
 
 <h4 id="format-string">Format string</h4>
 
@@ -70,16 +70,16 @@ The component will not assign a date value until a specific date is selected in 
 
 <h3 id="datepicker-props">Props</h3>
 
-| Prop                     | Type                                          | Description                                          |
-| :----------------------- | :-------------------------------------------- | :--------------------------------------------------- |
-| `value`                  | Date \| null                                  | Date value                                           |
+| Prop                     | Type                                          | Description                                                    |
+| :----------------------- | :-------------------------------------------- | :------------------------------------------------------------- |
+| `value`                  | Date \| null                                  | Date value                                                     |
 | `initialBrowseDate`      | Date                                          | Initial date to show in the calendar when no value is selected |
-| `min`                    | Date                                          | The earliest year the user can select                |
-| `max`                    | Date                                          | The latest year the user can select                  |
-| `timePrecision`          | "minute" \| "second" \| "millisecond" \| null | Show a time picker with the specified precision      |
-| `locale`                 | Locale                                        | Locale object for internationalization               |
-| `browseWithoutSelecting` | bool                                          | Wait with updating the date until a date is selected |
-| `isDisabledDate`         | ((dateToCheck: Date) => boolean) \| null      | Disallow specific dates                              |
+| `min`                    | Date                                          | The earliest year the user can select                          |
+| `max`                    | Date                                          | The latest year the user can select                            |
+| `timePrecision`          | "minute" \| "second" \| "millisecond" \| null | Show a time picker with the specified precision                |
+| `locale`                 | Locale                                        | Locale object for internationalization                         |
+| `browseWithoutSelecting` | bool                                          | Wait with updating the date until a date is selected           |
+| `isDisabledDate`         | ((dateToCheck: Date) => boolean) \| null      | Disallow specific dates                                        |
 
 <h2 id="isDisabledDate">Date disabling example</h2>
 

--- a/src/routes/docs/+page.md
+++ b/src/routes/docs/+page.md
@@ -32,6 +32,7 @@ The component will not assign a date value until a specific date is selected in 
 | Prop                     | Type                                          | Description                                                   |
 | :----------------------- | :-------------------------------------------- | :------------------------------------------------------------ |
 | `value`                  | Date \| null                                  | Date value                                                    |
+| `defaultDate`            | Date                                          | Default date to display in picker before value is assigned    |
 | `min`                    | Date                                          | The earliest value the user can select                        |
 | `max`                    | Date                                          | The latest value the user can select                          |
 | `placeholder`            | string                                        | Placeholder used when date value is null                      |
@@ -72,6 +73,7 @@ The component will not assign a date value until a specific date is selected in 
 | Prop                     | Type                                          | Description                                          |
 | :----------------------- | :-------------------------------------------- | :--------------------------------------------------- |
 | `value`                  | Date \| null                                  | Date value                                           |
+| `defaultDate`            | Date                                          | Default Date to use                                  |
 | `min`                    | Date                                          | The earliest year the user can select                |
 | `max`                    | Date                                          | The latest year the user can select                  |
 | `timePrecision`          | "minute" \| "second" \| "millisecond" \| null | Show a time picker with the specified precision      |


### PR DESCRIPTION
I've been using this library in production and it's been incredibly helpful. However, I needed the ability to specify a default date for the picker instead of always using  `new Date()`.

## Changes
- Added `initialBrowseDate` prop to `DateInput` component
- Added `initialBrowseDate` prop to `DatePicker` component

## Usage
```svelte
<DateInput initialBrowseDate={new Date(2024, 0, 1)} />
```